### PR TITLE
Add husky_diff_controller plugin back into description

### DIFF
--- a/urdf/base.urdf.xacro
+++ b/urdf/base.urdf.xacro
@@ -116,6 +116,20 @@
     <material>Gazebo/DarkGrey</material>
   </gazebo>
 
+  <gazebo>
+    <plugin name="husky_diff_controller" filename="libhusky_gazebo_plugins.so">
+      <alwaysOn>true</alwaysOn>
+      <updateRate>100.0</updateRate>
+      <backLeftJoint>joint_back_left_wheel</backLeftJoint>
+      <backRightJoint>joint_back_right_wheel</backRightJoint>
+      <frontLeftJoint>joint_front_left_wheel</frontLeftJoint>
+      <frontRightJoint>joint_front_right_wheel</frontRightJoint>
+      <wheelSeparation>${base_y_size}</wheelSeparation>
+      <wheelDiameter>${wheel_x_size}</wheelDiameter>
+      <torque>35</torque>	
+    </plugin>
+  </gazebo>
+
   <xacro:if value="$(arg imu_enabled)">
     <gazebo>
       <plugin name="imu_plugin" filename="libgazebo_ros_imu.so">


### PR DESCRIPTION
The husky_diff_controller plugin was romoved at some point, presumably to at some point be replaced by gazebo_ros_control, but until then we should add it back in to maintain functionality.
